### PR TITLE
fix: typegen never exits when used with cloudflare plugin

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ async function run() {
   const { runner, server } = await createContext();
   await runner.executeFile(path.resolve(import.meta.dirname, '../dist/empty.js'));
   await server.close();
+  process.exit(0);
 }
 
 const command = process.argv[2];


### PR DESCRIPTION
close #126

Closing the vite server won't close the wranler proxy