### PR TITLE
chore: restore and deprecate $params helper for incremental migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,31 @@ export const loader = async (request) => {
 }
 ```
 
+### Checking params
+
+> [!NOTE]
+> This function has been marked `@deprecated` in favor of React Router's
+> built-in type-safety, which provides strongly typed `params` to loaders,
+> actions, and components. This helper has been kept primarily to assist in
+> incremental migration.
+
+```typescript
+import { useParams } from "react-router";
+import { $params } from 'safe-routes'; // <-- Import $params helper.
+
+export const action = async ({ params }) => {
+  const { id } = $params("/posts/:id/update", params) // <-- It's type safe, try renaming `id` param.
+
+  // ...
+}
+
+export default function Component() {
+  const params = useParams();
+  const { id } = $params("/posts/:id/update", params);
+  ...
+}
+```
+
 ### Typed route ids
 
 safe-routes exports the `RouteId` type definition with the list of all valid route ids for your repository, and has a helper function `$routeId` that tells typescript to restrict the given string to one of the valid RouteId values.

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,3 +58,11 @@ export function $path(route: string, ...paramsOrQuery: Array<any>) {
 export function $routeId(routeId: string) {
   return routeId;
 }
+
+/** @deprecated Prefer to use React Router's typegen features instead. */
+export function $params(
+  _route: string,
+  params: { readonly [key: string]: string | undefined },
+) {
+  return params;
+}

--- a/src/template.ts
+++ b/src/template.ts
@@ -70,5 +70,14 @@ export function template(ctx: Context) {
   ): string;
 
   export function $routeId(routeId: RouteId): RouteId;
+
+  /** @deprecated Prefer to use React Router's typegen features instead. */
+  export function $params<
+    Route extends keyof RoutesWithParams,
+    Params extends RoutesWithParams[Route]["params"]
+  >(
+      route: Route,
+      params: { readonly [key: string]: string | undefined }
+  ): {[K in keyof Params]: string};
 }`;
 };

--- a/tests/__snapshots__/build.test.ts.snap
+++ b/tests/__snapshots__/build.test.ts.snap
@@ -186,5 +186,14 @@ exports[`gen route types 1`] = `
   ): string;
 
   export function $routeId(routeId: RouteId): RouteId;
+
+  /** @deprecated Prefer to use React Router's typegen features instead. */
+  export function $params<
+    Route extends keyof RoutesWithParams,
+    Params extends RoutesWithParams[Route]["params"]
+  >(
+      route: Route,
+      params: { readonly [key: string]: string | undefined }
+  ): {[K in keyof Params]: string};
 }"
 `;

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test, vi } from 'vitest';
-import { $path } from '../src';
+import { $params, $path } from '../src';
 import * as basename from '../src/basename.ts';
 
 vi.mock(import('../src/basename.ts'));
@@ -51,6 +51,10 @@ test('$path + catch all route', () => {
 
 test('optional segment', () => {
   expect($path('/tree?/:tree?', { tree: 'main' })).toBe('/tree/main');
+});
+
+test('$params', () => {
+  expect($params('/posts/:id', { id: '1' })).toStrictEqual({ id: '1' });
 });
 
 test('basename', async () => {


### PR DESCRIPTION
We (Docker) have quite a lot of routes that currently rely on `$params` from `remix-routes`.

Unfortunately, we aren't in a position to move entirely to RR7's type-safety features right away, but we'd still like to update to React Router 7. However, the lack of the `$params` helper makes this difficult.

I'd like to see `safe-routes` restore the `$params` helper to ease the migration path for larger apps, while marking it `@deprecated` to push consumers in the direction of React Router's built-in typegen features. This would unblock us from migrating to React Router 7 without having to migrate every one of our ~500 routes to use `react-router typegen` first.